### PR TITLE
add num_groups to batch repartition step in ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 * Fix monopartite batch assignment bug
+* Fix bug in ingest where partitioning was not performed according to defined groups
 
 ### Changed
 

--- a/examples/workflow_example.py
+++ b/examples/workflow_example.py
@@ -18,9 +18,11 @@ spark_session: SparkSession = (
 
 purchase_df: DataFrame = spark_session.createDataFrame(data=...)
 
+NUM_GROUPS = 8
+
 # Create batches and groups
 batched_purchase_df = group_and_batch_spark_dataframe(
-    purchase_df, "customer_id", "store_id", 8
+    purchase_df, "customer_id", "store_id", NUM_GROUPS
 )
 
 # Load to Neo4j

--- a/neo4j_parallel_spark_loader/monopartite/batching.py
+++ b/neo4j_parallel_spark_loader/monopartite/batching.py
@@ -39,16 +39,15 @@ def create_ingest_batches_from_groups(spark_dataframe: DataFrame) -> DataFrame:
         coloring_data, ["source_group", "target_group", "batch"]
     )
 
-    reverse_coloring_df = (coloring_df
-                           .filter(col("source_group") != col("target_group"))
-                           .select(
-                               col("target_group").alias("source_group"),
-                               col("source_group").alias("target_group"),
-                               col("batch"))
+    reverse_coloring_df = coloring_df.filter(
+        col("source_group") != col("target_group")
+    ).select(
+        col("target_group").alias("source_group"),
+        col("source_group").alias("target_group"),
+        col("batch"),
     )
 
     coloring_df = coloring_df.union(reverse_coloring_df)
-
 
     # Join the DataFrames
     result_df = spark_dataframe.join(


### PR DESCRIPTION
# Description

Add `num_groups` parameter to the `batch.repartition` step during ingest. we suspect partitioning was not being performed appropriately. 


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity


Complexity: LOW

## How Has This Been Tested?
- [ ] Unit tests
- [x] Integration tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated if appropriate
- [x] Unit tests have been updated
- [ ] Integration tests have been updated
- [x] Examples have been updated
- [x] CHANGELOG.md updated if appropriate