### PR TITLE
build_relationship bug fix

### DIFF
--- a/neo4j_parallel_spark_loader/utils/build_relationship.py
+++ b/neo4j_parallel_spark_loader/utils/build_relationship.py
@@ -70,7 +70,8 @@ def build_relationship(
     else:
         print("Building in series")
         df = (
-            df.write.format("org.neo4j.spark.DataSource")
+            df.coalesce(1)
+            .write.format("org.neo4j.spark.DataSource")
             .mode("Overwrite")
             .options(**options)
             .save()


### PR DESCRIPTION
# Description

build_relationship function was not calling coalesce(1) in the serial path.  This caused the job to spread across workers and possibly hit a deadlock.



## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Low

Complexity:

## How Has This Been Tested?
- [ ] Unit tests
- [x] Integration tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated if appropriate
- [ ] Unit tests have been updated
- [ ] Integration tests have been updated
- [ ] Examples have been updated
- [ ] CHANGELOG.md updated if appropriate